### PR TITLE
Make ReprVisitor return a string instead of bytes

### DIFF
--- a/esprima/visitor.py
+++ b/esprima/visitor.py
@@ -155,10 +155,10 @@ class NodeVisitor(Visitor):
 
 
 class ReprVisitor(Visitor):
-    def visit(self, obj, indent=4, nl=b"\n", sp=b"", skip=()):
+    def visit(self, obj, indent=4, nl="\n", sp="", skip=()):
         self.level = 0
         if isinstance(indent, int):
-            indent = b" " * indent
+            indent = " " * indent
         self.indent = indent
         self.nl = nl
         self.sp = sp
@@ -166,7 +166,7 @@ class ReprVisitor(Visitor):
         return super(ReprVisitor, self).visit(obj)
 
     def visit_RecursionError(self, obj):
-        yield Visited(b"...")
+        yield Visited("...")
 
     def visit_Object(self, obj):
         value_repr = yield obj.__dict__
@@ -185,17 +185,17 @@ class ReprVisitor(Visitor):
                 v = yield item
                 items.append(v)
             if items:
-                value_repr = b"[%s%s%s%s%s%s%s]" % (
+                value_repr = "[%s%s%s%s%s%s%s]" % (
                     self.sp,
                     self.nl,
                     indent2,
-                    (b",%s%s%s" % (self.nl, self.sp, indent2)).join(items),
+                    (",%s%s%s" % (self.nl, self.sp, indent2)).join(items),
                     self.nl,
                     indent1,
                     self.sp,
                 )
             else:
-                value_repr = b"[]"
+                value_repr = "[]"
         finally:
             self.level -= 1
 
@@ -212,19 +212,19 @@ class ReprVisitor(Visitor):
             for k, item in obj.items():
                 if item is not None and not k.startswith('_') and k not in self.skip:
                     v = yield item
-                    items.append(b"%s: %s" % (k, v))
+                    items.append("%s: %s" % (k, v))
             if items:
-                value_repr = b"{%s%s%s%s%s%s%s}" % (
+                value_repr = "{%s%s%s%s%s%s%s}" % (
                     self.sp,
                     self.nl,
                     indent2,
-                    (b",%s%s%s" % (self.nl, self.sp, indent2)).join(items),
+                    (",%s%s%s" % (self.nl, self.sp, indent2)).join(items),
                     self.nl,
                     indent1,
                     self.sp,
                 )
             else:
-                value_repr = b"{}"
+                value_repr = "{}"
         finally:
             self.level -= 1
 
@@ -254,7 +254,7 @@ class ReprVisitor(Visitor):
 class ToDictVisitor(Visitor):
     def visit_RecursionError(self, obj):
         yield Visited({
-            b'error': "Infinite recursion detected...",
+            'error': "Infinite recursion detected...",
         })
 
     def visit_Object(self, obj):


### PR DESCRIPTION
There are string objects mixing with bytes formating in the ReprVisitor,
which raise exceptions whenever the user tries to print an object
(this is an issue only on Python3).

Either convert everything to bytes or to str before manipulating it.

To repro the issue :

```
PS F:\Dev\esprima-python> git log 
commit 86a03eec42df6d1e3c7c0ffa31a887ac37ef02ab (HEAD -> master, origin/master, origin/HEAD, repr_bug)
Author: German M. Bravo <german.mb@deipi.com>
Date:   Wed Oct 18 11:47:31 2017 -0500

    Version bump to v4.0.0-dev.12
PS F:\Dev\esprima-python> python .\setup.py install
[... snipped for brevity ...]
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist\esprima-4.0.0.dev12-py3.5.egg' and adding 'build\bdist.win-amd64\egg' to it
removing 'build\bdist.win-amd64\egg' (and everything under it)
Processing esprima-4.0.0.dev12-py3.5.egg
Copying esprima-4.0.0.dev12-py3.5.egg to f:\dev\esprima-python\env\lib\site-packages
Adding esprima 4.0.0.dev12 to easy-install.pth file
Installing esprima-script.py script to F:\Dev\esprima-python\env\Scripts
Installing esprima.exe script to F:\Dev\esprima-python\env\Scripts

Installed f:\dev\esprima-python\env\lib\site-packages\esprima-4.0.0.dev12-py3.5.egg
Processing dependencies for esprima==4.0.0.dev12
Finished processing dependencies for esprima==4.0.0.dev12
(env) PS F:\Dev\esprima-python> git branch repr_bug
(env) PS F:\Dev\esprima-python> python
Python 3.5.2 (v3.5.2:4def2a2901a5, Jun 25 2016, 22:18:55) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import esprima
>>> with open("test/fixtures/directive-prolog/migrated_0000.js") as test_case:
...     ast = esprima.parse(test_case.read())
...
>>> print(ast)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "F:\Dev\esprima-python\esprima\objects.py", line 43, in __repr__
    return ReprVisitor().visit(self)
  File "F:\Dev\esprima-python\esprima\visitor.py", line 166, in visit
    return super(ReprVisitor, self).visit(obj)
  File "F:\Dev\esprima-python\esprima\visitor.py", line 95, in visit
    stack.append((last.send(last_result), None))
  File "F:\Dev\esprima-python\esprima\visitor.py", line 215, in visit_dict
    items.append(b"%s: %s" % (k, v))
TypeError: %b requires bytes, or an object that implements __bytes__, not 'str'
>>>
```


With the fix :

```
>>> print(ast)
{
    type: "Program",
    body: [
        {
            type: "ExpressionStatement",
            expression: {
                type: "CallExpression",
                callee: {
                    expression: False,
                    async: False,
                    params: [],
                    body: {
                        type: "BlockStatement",
                        body: [
                            {
                                type: "ExpressionStatement",
                                expression: {
                                    type: "Literal",
                                    raw: "'use\\x20strict'",
                                    value: "use strict"
                                },
                                directive: "use\\x20strict"
                            },
                            {
                                type: "WithStatement",
                                object: {
                                    type: "Identifier",
                                    name: "i"
                                },
                                body: {
                                    type: "EmptyStatement"
                                }
                            }
                        ]
                    },
                    type: "FunctionExpression",
                    generator: False
                },
                arguments: []
            }
        }
    ],
    sourceType: "script"
}
```