### PR TITLE
PKG: Include readme and license files in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.rst
+include LICENSE.BSD


### PR DESCRIPTION
By adding the files to `MANIFEST.in`, we ensure they will be included in the source distribution created via `python setup.py sdist`.